### PR TITLE
Updating installations instructions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: julia
 os:
   - linux
 julia:
-  - 1.0
+  - 1.1.0
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,20 +1,19 @@
 name = "ComputationalHomology"
 uuid = "9393a4d0-be1e-45b0-9991-b60434c721e6"
-version = "0.4.0"
 keywords = ["computational homology", "computational topology", "persistent homology"]
 license = "MIT"
 desc = "A Julia package for computational topology and homology"
 repository = "https://github.com/wildart/ComputationalHomology.jl.git"
-
+version = "0.4.0"
 
 [deps]
+BoundingSphere = "747eb165-47b8-53f2-ad32-9704a7dfc50a"
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SmithNormalForm = "ba71f38f-f508-439b-ac77-437f86a20aa1"
-Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-BoundingSphere = "747eb165-47b8-53f2-ad32-9704a7dfc50a"
 
 [compat]
 SmithNormalForm = "0.2.2"

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ This package provides various computational homology tools for cellular complexe
 This package requires [SmithNormalForm.jl](https://github.com/wildart/SmithNormalForm.jl/) package for work.
 
 ```
-pkg> add https://github.com/wildart/SmithNormalForm.jl.git#0.2.1
-pkg> add https://github.com/wildart/ComputationalHomology.jl.git#0.2.0
+pkg> add https://github.com/wildart/ComputationalHomology.jl.git#0.2.2
 ```
 
 ## Features


### PR DESCRIPTION
Adds better installation instructions for SmithNormalForm.

Same deal with TDA. I ran `instantiate; activate .` and did see an update in the Project.toml. It looks like just reordering and minor upgrades since the changed packages aren't versioned. The big thing here is updating the installation to remove SmithNormalForm from the instructions. 